### PR TITLE
Fix/update function for tags

### DIFF
--- a/R/drop.R
+++ b/R/drop.R
@@ -51,10 +51,10 @@ drop_update_meta <- function(drop, ...){
                access = args$access %||% drop$access,
                license = NULL,
                #time_created = NULL,
-               time_last_updated = args$time_last_updated %||% drop$time_last_updated,
-               tags = args$tags %||% drop$tags)
+               time_last_updated = args$time_last_updated %||% drop$time_last_updated)
   drop <- modifyList(drop, info)
   drop$sources <- args$sources %||% drop$sources
+  drop$tags <- args$tags %||% drop$tags
   drop
 }
 

--- a/R/dsviz.R
+++ b/R/dsviz.R
@@ -59,11 +59,11 @@ dsviz_update_meta <- function(dv, ...){
                #time_created = NULL,
                time_last_updated = args$time_last_updated %||% dv$time_last_updated,
                formats = args$formats %||% dv$formats,
-               tags = args$tags %||% dv$tags,
                dsapp = args$dsapp %||% dv$dsapp,
                fringe = args$fringe %||% dv$fringe)
   dv <- modifyList(dv, info)
   dv$sources <- args$sources %||% dv$sources
+  dv$tags <- args$tags %||% dv$tags
   dv
 }
 

--- a/tests/testthat/test-dspins_drop.R
+++ b/tests/testthat/test-dspins_drop.R
@@ -47,6 +47,13 @@ test_that("drop_update_meta", {
   expect_equal(dp5$sources, update_sources)
   expect_equal(dp5$name, "this file")
 
+  tag <- list('one tag')
+  tags <- list(c('one tag', 'another tag'))
+  dp6 <- drop_update_meta(dp0, tags = tag)
+  dp7 <- drop_update_meta(dp6, tags = tags)
+  expect_equal(dp6$tags, tag)
+  expect_equal(dp7$tags, tags)
+
   expect_warning(drop_update_meta(dp0, filesize = 300),
                  "Cannot update filesize. Removing from meta.")
 

--- a/tests/testthat/test-dsviz.R
+++ b/tests/testthat/test-dsviz.R
@@ -55,6 +55,13 @@ test_that("dsviz_update_meta", {
   expect_equal(dv5$sources, update_sources)
   expect_equal(dv5$name, "this chart")
 
+  tag <- list('one tag')
+  tags <- list(c('one tag', 'another tag'))
+  dv6 <- dsviz_update_meta(dv0, tags = tag)
+  dv7 <- dsviz_update_meta(dv6, tags = tags)
+  expect_equal(dv6$tags, tag)
+  expect_equal(dv7$tags, tags)
+
   expect_warning(dsviz_update_meta(dv0, viz_type = "ggplot"),
                  "Cannot update viz_type. Removing from meta.")
 


### PR DESCRIPTION
Fixing functions `drop_update_meta` and `dsviz_update_meta` so that `tags` can be updated. 