### PR TITLE
Update URLs for sharing

### DIFF
--- a/R/dspin_urls.R
+++ b/R/dspin_urls.R
@@ -45,7 +45,7 @@ element_type <- function(x){
 get_element_urls <- function(element, folder, bucket_id){
 
   element_slug <- element$slug
-  baselink <-  file.path(paste0("https://s3.amazonaws.com/", bucket_id, ".dskt.ch"), folder, element_slug)
+  baselink <-  file.path(paste0("https://", bucket_id, ".dskt.ch"), folder, element_slug)
   link <-  file.path("https://datasketch.co", folder, element_slug)
   el_type <- element_type(element)
 

--- a/R/pin_drop.R
+++ b/R/pin_drop.R
@@ -27,16 +27,19 @@ pin.drop <- function(drop, name = NULL, description = NULL, board = NULL, ...) {
   metadata$description <- NULL
 
   format <- drop$format
+
+  url_base_path <- glue::glue("https://{bucket}/{folder}/{slug}/{slug}")
+
   metadata$files <- list(list(path = glue::glue(paste0("{slug}.", format)),
                               format = format,
-                              url = glue::glue("https://s3.amazonaws.com/{bucket}/{folder}/{slug}/{slug}.{format}"))) %>%
+                              url = glue::glue("{url_base_path}.{format}"))) %>%
     setNames(format)
 
 
   metadata$share <- list(list(link =  glue::glue("https://datasketch.co/{folder}/{slug}"),
-                              permalink =  glue::glue("https://s3.amazonaws.com/{bucket}/{folder}/{slug}/{slug}.{format}"),
+                              permalink =  glue::glue("{url_base_path}.{format}"),
                               embed =  paste0('<iframe src="',
-                                              glue::glue("https://s3.amazonaws.com/{bucket}/{folder}/{slug}/{slug}.{format}"),
+                                              glue::glue("{url_base_path}.{format}"),
                                               '" frameborder=0 width="100%" height="400px"></iframe>'))) %>%
     setNames(format)
 

--- a/R/pin_dsviz.R
+++ b/R/pin_dsviz.R
@@ -31,34 +31,36 @@ pin.dsviz <- function(dv, name = NULL, description = NULL, board = NULL, ...) {
   if(dv$type == "htmlwidget") formats <- c("html", "png")
   if(dv$type == "gg") formats <- c("png", "svg")
 
+  url_base_path <- glue::glue("https://{bucket}/{folder}/{slug}/{slug}")
+
   metadata$files <- lapply(formats, function(x){
     list(
       path = glue::glue(paste0("{slug}.",x)),
       format = x,
-      url = glue::glue("https://s3.amazonaws.com/{bucket}/{folder}/{slug}/{slug}.{x}")
+      url = glue::glue("{url_base_path}.{x}")
     )
   }) %>% setNames(formats)
 
   share <- list(
     html = list(
       link =  glue::glue("https://datasketch.co/{folder}/{slug}"),
-      permalink =  glue::glue("https://s3.amazonaws.com/{bucket}/{folder}/{slug}/{slug}.html"),
+      permalink =  glue::glue("{url_base_path}.html"),
       embed =  paste0('<iframe src="',
-                      glue::glue("https://s3.amazonaws.com/{bucket}/{folder}/{slug}/{slug}.html"),
+                      glue::glue("{url_base_path}.html"),
                       '" frameborder=0 width="100%" height="400px"></iframe>')
     ),
     png = list(
       link =  glue::glue("https://datasketch.co/{folder}/{slug}"),
-      permalink =  glue::glue("https://s3.amazonaws.com/{bucket}/{folder}/{slug}/{slug}.png"),
+      permalink =  glue::glue("{url_base_path}.png"),
       embed =  paste0('<img src="',
-                      glue::glue("https://s3.amazonaws.com/{bucket}/{folder}/{slug}/{slug}.png"),
+                      glue::glue("{url_base_path}.png"),
                       '"></img>')
     ),
     svg = list(
       link =  glue::glue("https://datasketch.co/{folder}/{slug}"),
-      permalink =  glue::glue("https://s3.amazonaws.com/{bucket}/{folder}/{slug}/{slug}.svg"),
+      permalink =  glue::glue("{url_base_path}.svg"),
       embed =  paste0('<img src="',
-                      glue::glue("https://s3.amazonaws.com/{bucket}/{folder}/{slug}/{slug}.svg"),
+                      glue::glue("{url_base_path}.svg"),
                       '></img>')
     )
   )

--- a/R/pin_fringe.R
+++ b/R/pin_fringe.R
@@ -32,28 +32,30 @@ pin.fringe <- function(f, name = NULL, description = NULL, board = NULL, ...) {
   metadata$group <- f$group
   metadata$frtype <- as.character(f$frtype)
 
+  url_base_path <- glue::glue("https://{bucket}/{folder}/{slug}/{slug}")
+
   formats <- c(c("csv", "json"), args$download_formats)
   metadata$files <- lapply(formats, function(x){
     list(
       path = glue::glue("{slug}.{x}"),
       format = x,
-      url = glue::glue("https://s3.amazonaws.com/{bucket}/{folder}/{slug}/{slug}.{x}")
+      url = glue::glue("{url_base_path}.{x}")
     )
   }) %>% setNames(formats)
 
   metadata$share <- list(
     html = list(
       link =  glue::glue("https://datasketch.co/{folder}/{slug}"),
-      permalink =  glue::glue("https://s3.amazonaws.com/{bucket}/{folder}/{slug}/{slug}.html"),
+      permalink =  glue::glue("{url_base_path}.html"),
       embed =  paste0('<iframe src="',
-                      glue::glue("https://s3.amazonaws.com/{bucket}/{folder}/{slug}/{slug}.html"),
+                      glue::glue("{url_base_path}.html"),
                       '" frameborder=0 width="100%" height="400px"></iframe>')),
     csv = list(
       link =  glue::glue("https://datasketch.co/{folder}/{slug}"),
-      permalink =  glue::glue("https://s3.amazonaws.com/{bucket}/{folder}/{slug}/{slug}.csv")),
+      permalink =  glue::glue("{url_base_path}.csv")),
     json = list(
       link =  glue::glue("https://datasketch.co/{folder}/{slug}"),
-      permalink =  glue::glue("https://s3.amazonaws.com/{bucket}/{folder}/{slug}/{slug}.json"))
+      permalink =  glue::glue("{url_base_path}.json"))
   )
 
   f$files <- metadata$files

--- a/tests/testthat/test-dspins_drop.R
+++ b/tests/testthat/test-dspins_drop.R
@@ -9,12 +9,30 @@ test_that("dspins drop", {
   path <- file.path(sample_path, "sample.txt")
 
   current_title <- paste0("Sample drop - ", as.character(Sys.time()))
+  current_slug <- create_slug(current_title)
   dp <- drop(sample_path, name = current_title)
   pin_url <- pin(dp, folder = folder, bucket_id = bucket_id)
 
   pins <- dspins::dspin_list(folder, bucket_id)
-  expect_true(any(pins$name == create_slug(current_title)))
+  expect_true(any(pins$name == current_slug))
 
+  # test meta data
+  url_base_path <- paste0("https://",bucket_id,".dskt.ch/",folder,"/",current_slug,"/",current_slug)
+  url_share <- paste0("https://datasketch.co/",folder,"/",current_slug)
+
+  meta_info_pin <- pins %>% filter(name == current_slug)
+
+  files_paths <- sub('.*\\/', '',  meta_info_pin$files_paths[[1]])
+  expect_true(length(setdiff(files_paths, c("sample.html", "sample.jpg", "sample.pdf", "sample.png", "sample.txt"))) == 0)
+
+  expect_equal(meta_info_pin$files$`1`$path, paste0(current_slug,"."))
+  expect_equal(meta_info_pin$files$`1`$url, paste0(url_base_path,"."))
+
+  expect_equal(meta_info_pin$share$`1`$link, url_share)
+  expect_equal(meta_info_pin$share$`1`$permalink, paste0(url_base_path,"."))
+  expect_equal(meta_info_pin$share$`1`$embed, paste0("<iframe src=\"",paste0(url_base_path,"."),"\" frameborder=0 width=\"100%\" height=\"400px\"></iframe>"))
+
+  # test errors and warnings
   expect_error(pin(dp), "Need a folder to save drop")
 
   expect_message(pin(dp, folder = folder), "No bucket_id specified. Using 'user.dskt.ch' by default.")

--- a/tests/testthat/test-dsviz.R
+++ b/tests/testthat/test-dsviz.R
@@ -7,14 +7,38 @@ test_that("dsviz hgchmagic", {
 
   library(hgchmagic)
   current_title <- paste0("Sample hgdviz - ", as.character(Sys.time()))
+  current_slug <- create_slug(current_title)
   viz <- hgchmagic::hgch_bar_Cat(tibble(a = c("a","b")))
 
   dv <- dsviz(viz, name = current_title)
   pin_url <- pin(dv, folder = folder, bucket_id = bucket_id)
 
   pins <- dspins::dspin_list(folder, bucket_id)
-  expect_true(any(pins$name == create_slug(current_title)))
+  expect_true(any(pins$name == current_slug))
 
+  # test meta data
+  url_base_path <- paste0("https://",bucket_id,".dskt.ch/",folder,"/",current_slug,"/",current_slug)
+  url_share <- paste0("https://datasketch.co/",folder,"/",current_slug)
+
+  meta_info_pin <- pins %>% filter(name == current_slug)
+  expect_equal(unlist(meta_info_pin$formats), c("html", "png"))
+
+  expect_equal(meta_info_pin$files$html$path, paste0(current_slug,".html"))
+  expect_equal(meta_info_pin$files$html$url, paste0(url_base_path,".html"))
+
+  expect_equal(meta_info_pin$files$png$path, paste0(current_slug,".png"))
+  expect_equal(meta_info_pin$files$png$url, paste0(url_base_path,".png"))
+
+  expect_equal(meta_info_pin$share$html$link, url_share)
+  expect_equal(meta_info_pin$share$html$permalink, paste0(url_base_path,".html"))
+  expect_equal(meta_info_pin$share$html$embed, paste0("<iframe src=\"",paste0(url_base_path,".html"),"\" frameborder=0 width=\"100%\" height=\"400px\"></iframe>"))
+
+  expect_equal(meta_info_pin$share$png$link, url_share)
+  expect_equal(meta_info_pin$share$png$permalink, paste0(url_base_path,".png"))
+  expect_equal(meta_info_pin$share$png$embed, paste0("<img src=\"",paste0(url_base_path,".png"),"\"></img>"))
+
+
+  # test errors and warnings
   expect_error(pin(dv), "Need a folder to save dsviz")
 
   expect_message(pin(dv, folder = folder), "No bucket_id specified. Using 'user.dskt.ch' by default.")

--- a/tests/testthat/test-fringe.R
+++ b/tests/testthat/test-fringe.R
@@ -7,6 +7,7 @@ test_that("fringe", {
 
   library(homodatum)
   current_title <- paste0("Sample fringe - ", as.character(Sys.time()))
+  current_slug <- create_slug(current_title)
   df <- homodatum::sample_data("Cat")
 
   f <- fringe(df, name = current_title)
@@ -15,6 +16,26 @@ test_that("fringe", {
   pins <- dspins::dspin_list(folder, bucket_id)
   expect_true(any(pins$title == current_title))
 
+  # test meta data
+  url_base_path <- paste0("https://",bucket_id,".dskt.ch/",folder,"/",current_slug,"/",current_slug)
+  url_share <- paste0("https://datasketch.co/",folder,"/",current_slug)
+
+  meta_info_pin <- pins %>% filter(name == current_slug)
+  expect_equal(names(meta_info_pin$stats), c("nrow", "ncol"))
+
+  expect_equal(meta_info_pin$files$csv$path, paste0(current_slug,".csv"))
+  expect_equal(meta_info_pin$files$csv$url, paste0(url_base_path,".csv"))
+
+  expect_equal(meta_info_pin$files$json$path, paste0(current_slug,".json"))
+  expect_equal(meta_info_pin$files$json$url, paste0(url_base_path,".json"))
+
+  expect_equal(meta_info_pin$share$csv$link, url_share)
+  expect_equal(meta_info_pin$share$csv$permalink, paste0(url_base_path,".csv"))
+
+  expect_equal(meta_info_pin$share$json$link, url_share)
+  expect_equal(meta_info_pin$share$json$permalink, paste0(url_base_path,".json"))
+
+  # test errors and warnings
   expect_error(pin(f), "Need a folder to save fringe")
 
   expect_message(pin(f, folder = folder), "No bucket_id specified. Using 'user.dskt.ch' by default.")

--- a/tests/testthat/test_dspin_urls.R
+++ b/tests/testthat/test_dspin_urls.R
@@ -14,12 +14,12 @@ test_that("User url", {
 
   ## Urls generation
   expect_equal(paste0("https://datasketch.co/",user_name, "/", f$slug), urls$link)
-  expect_equal(paste0("https://s3.amazonaws.com/",bucket_id,".dskt.ch/",user_name,"/", f$slug, "/", f$slug, ".json"),
+  expect_equal(paste0("https://",bucket_id,".dskt.ch/",user_name,"/", f$slug, "/", f$slug, ".json"),
                urls$permalink)
   # Pin url
   urls <- dspin_urls(element = f, user_name = user_name, bucket_id = bucket_id, download_formats = "xlsx")
   expect_equal(urls$link, paste0("https://datasketch.co/",user_name,"/", f$slug))
-  expect_equal(urls$permalink, paste0("https://s3.amazonaws.com/",bucket_id,".dskt.ch/",user_name,"/",f$slug,"/",f$slug,".json"))
+  expect_equal(urls$permalink, paste0("https://",bucket_id,".dskt.ch/",user_name,"/",f$slug,"/",f$slug,".json"))
 
   # DSVIZ HTMLWIDGETS
 
@@ -32,14 +32,14 @@ test_that("User url", {
 
   ## Urls generation
   urls <- get_element_urls(dvhg, folder = user_name, bucket_id = bucket_id)
-  expect_equal(urls$permalink, paste0("https://s3.amazonaws.com/",bucket_id,".dskt.ch/",user_name,"/", dvhg$slug, "/", dvhg$slug, ".html"))
+  expect_equal(urls$permalink, paste0("https://",bucket_id,".dskt.ch/",user_name,"/", dvhg$slug, "/", dvhg$slug, ".html"))
   expect_equal(urls$iframe_embed,
-               paste0("<iframe src=\"",paste0("https://s3.amazonaws.com/",bucket_id,".dskt.ch/",user_name,"/", dvhg$slug, "/", dvhg$slug, ".html"),"\" frameborder=0 width=\"100%\" height=\"400px\"></iframe>"))
+               paste0("<iframe src=\"",paste0("https://",bucket_id,".dskt.ch/",user_name,"/", dvhg$slug, "/", dvhg$slug, ".html"),"\" frameborder=0 width=\"100%\" height=\"400px\"></iframe>"))
 
   # pin viz
   urls <- dspin_urls(element = dvhg, user_name = user_name, bucket_id = bucket_id)
   expect_equal(urls$link, paste0("https://datasketch.co/",user_name,"/", dvhg$slug))
-  expect_equal(urls$permalink, paste0("https://s3.amazonaws.com/",bucket_id,".dskt.ch/",user_name,"/",dvhg$slug,"/",dvhg$slug,".html"))
+  expect_equal(urls$permalink, paste0("https://",bucket_id,".dskt.ch/",user_name,"/",dvhg$slug,"/",dvhg$slug,".html"))
 
   # DSVIZ GGMAGIC
   library(ggmagic)
@@ -48,12 +48,12 @@ test_that("User url", {
 
   ## Urls generation
   urls <- get_element_urls(dvgg, folder = user_name, bucket_id = bucket_id)
-  expect_equal(urls$permalink, paste0("https://s3.amazonaws.com/",bucket_id,".dskt.ch/",user_name,"/",dvgg$slug,"/",dvgg$slug,".png"))
+  expect_equal(urls$permalink, paste0("https://",bucket_id,".dskt.ch/",user_name,"/",dvgg$slug,"/",dvgg$slug,".png"))
 
   # pin viz
   urls <- dspin_urls(element = dvgg, user_name = user_name, bucket_id = bucket_id)
   expect_equal(urls$link, paste0("https://datasketch.co/",user_name,"/", dvgg$slug))
-  expect_equal(urls$permalink, paste0("https://s3.amazonaws.com/",bucket_id,".dskt.ch/",user_name,"/",dvgg$slug,"/",dvgg$slug,".png"))
+  expect_equal(urls$permalink, paste0("https://",bucket_id,".dskt.ch/",user_name,"/",dvgg$slug,"/",dvgg$slug,".png"))
 
 
 })


### PR DESCRIPTION
Updating URLs from `https://s3.amazonaws.com/user.dskt.ch/<username>/<slug>/<resource>` to `https://user.dskt.ch/<username>/<slug>/<resource>` and extending tests for `pin_*` so that URLs are tested.