### PR TITLE
Ensure unique formats pin fringe

### DIFF
--- a/R/pin_fringe.R
+++ b/R/pin_fringe.R
@@ -35,7 +35,7 @@ pin.fringe <- function(f, name = NULL, description = NULL, board = NULL, ...) {
 
   url_base_path <- glue::glue("https://{bucket}/{folder}/{slug}/{slug}")
 
-  formats <- c(c("csv", "json"), args$download_formats)
+  formats <- unique(c(c("csv", "json"), args$download_formats))
   metadata$files <- lapply(formats, function(x){
     list(
       path = glue::glue("{slug}.{x}"),


### PR DESCRIPTION
Adding a `unique` statement in `pin.fringe` so that there can't be duplicates in `formats` (duplicates in formats create duplicates in the `data.txt` which create problems in the display of pins in DS profiles).