### PR TITLE
Add title to dsviz and drop metadata

### DIFF
--- a/R/pin_drop.R
+++ b/R/pin_drop.R
@@ -24,6 +24,7 @@ pin.drop <- function(drop, name = NULL, description = NULL, board = NULL, ...) {
 
   name <- create_slug(name) %||% slug
   metadata <- drop
+  metadata$title <- drop$name
   metadata$name <- NULL
   metadata$description <- NULL
 

--- a/R/pin_dsviz.R
+++ b/R/pin_dsviz.R
@@ -8,6 +8,7 @@ pin.dsviz <- function(dv, name = NULL, description = NULL, board = NULL, ...) {
   saveRDS(dv, file.path(path, "data.rds"), version = 2)
 
   metadata <- dv
+  metadata$title <- dv$name
   metadata$viz <- NULL
   metadata$name <- NULL
   metadata$description <- NULL


### PR DESCRIPTION
When `dsviz` and `drop` files are saved from an app, a `title` parameter is now added to the metadata (like for `fringe` files) - this means that for files saved with this updated version of `dspins`, titles of data loaded/saved in DS profile are now displayed properly (rather than slugs).