### PR TITLE
Fix png preview

### DIFF
--- a/R/dsviz.R
+++ b/R/dsviz.R
@@ -75,8 +75,10 @@ dsviz_write <- function(dv, path, ...){
   args <- list(...)
   viz <- dv$viz
   type <- dsviz_type(viz)
-  viz_width <- dv$width
-  viz_height <- dv$height
+  # viz_width <- dv$width
+  # viz_height <- dv$height
+  viz_width <- 660
+  viz_height <- 500
 
   viz_path <- file.path(path, dv$slug)
 

--- a/R/dsviz.R
+++ b/R/dsviz.R
@@ -9,7 +9,7 @@ dsviz <- function(viz, name = NULL, description = NULL, ...){
   }
   if(type == "gg"){
     formats <- c("png", "svg")
-    width <- args$width %||% 600L
+    width <- args$width %||% 650L
   }
 
 
@@ -22,7 +22,7 @@ dsviz <- function(viz, name = NULL, description = NULL, ...){
     type = type,
     viz_type = type,
     width = width,
-    height = as.integer(args$height) %||% 400L,
+    height = as.integer(args$height) %||% 500L,
     access = args$access %||% "private",
     license = NULL,
     #time_created = NULL,
@@ -75,10 +75,8 @@ dsviz_write <- function(dv, path, ...){
   args <- list(...)
   viz <- dv$viz
   type <- dsviz_type(viz)
-  # viz_width <- dv$width
-  # viz_height <- dv$height
-  viz_width <- 660
-  viz_height <- 500
+  viz_width <- dv$width
+  viz_height <- dv$height
 
   viz_path <- file.path(path, dv$slug)
 
@@ -101,7 +99,7 @@ dsviz_write <- function(dv, path, ...){
     if (!webshot::is_phantomjs_installed())
       webshot::install_phantomjs()
     webshot::webshot(paste0(viz_path,".html"), paste0(viz_path,".png"),
-                     vwidth = viz_width, vheight = viz_height, delay = 0.2)
+                     vheight = viz_height, delay = 0.2)
     file.remove(filepath)
 
   }

--- a/tests/testthat/test_dspin_urls.R
+++ b/tests/testthat/test_dspin_urls.R
@@ -24,7 +24,7 @@ test_that("User url", {
   # DSVIZ HTMLWIDGETS
 
   library(hgchmagic)
-  hg <- hgch_bar_Cat(data.frame(Thinks = c("Rocks", "Paper", "Cuts")), title = "Nice chart")
+  hg <- hgch_donut_Cat(data.frame(Thinks = c("Rocks", "Paper", "Cuts")), title = "Nice chart", subtitle = "Nice subtitle")
 
   expect_error(get_element_urls(hg, folder = user_name, bucket_id = bucket_id), "Element must be fringe or dsviz")
   dvhg <- dsviz(hg, height = 600)
@@ -43,7 +43,8 @@ test_that("User url", {
 
   # DSVIZ GGMAGIC
   library(ggmagic)
-  gg <- gg_bar_Cat(d = data.frame(x=c("a","a","b")), title = "Another Chart")
+  gg <- gg_bar_Cat(d = data.frame(x=c("a","a","b"),
+                                  stringsAsFactors = FALSE), title = "Another Chart")
   dvgg <- dsviz(gg)
 
   ## Urls generation


### PR DESCRIPTION
Saving `png` for chart preview with same proportions as the original `htmlwidget`.